### PR TITLE
feat: rendering of providers

### DIFF
--- a/providers/index.md
+++ b/providers/index.md
@@ -7,6 +7,57 @@ layout: page
 
 <section class="light-grey">
 
-Providers - list of them with logos, link to their offer
+## Providers
 
+list of them with logos, link to their offer - TODO text
+
+  <esa-cards v-if="providers.length" style="min-height: 500px">
+    <esa-card
+      v-for="provider in providers"
+      :key="provider.id"
+      :title="provider.id"
+      :description="`
+        ${provider.Description}${provider['NoR Offering'] ? `<br /><br /><a href='${provider['NoR Offering']}' target='_blank'>NoR Offering</a>` : ''}
+        ${provider.narratives?.length ? `<br /><br />Stories: ${provider.narratives.map(n => `<a href='${withBase(`/story/?id=${n.file.split(/\/|\\/).pop().replace('.md', '')}`)}'>${n.title}</a>`).join(', ')}` : ''}
+        ${provider.indicators?.length ? `<br /><br />Indicators: ${provider.indicators.map(i => `<a href='${withBase(`/explore/?indicator=${i.code}`)}'>${i.title}</a>`).join(', ')}` : ''}
+      `"
+      :icon="`<img src='${provider.Logo}'' height='60' style='max-width: 100%; object-fit: contain' />`"
+      :link="provider.Url"
+      action="Website"
+    ></esa-card>
+  </esa-cards>
 </section>
+
+<script setup>
+  import { onMounted, ref } from "vue";
+  import { withBase } from 'vitepress';
+
+  const indicators = ref([]);
+  const providers = ref([]);
+  const narratives = ref([]);
+
+  const getIndicatorsForProvider = (providerKey) => indicators.value.filter(i => i.providers?.includes(providerKey));
+  const getNarrativesForProvider = (providerKey) => narratives.value.filter(n => n.provider === providerKey);
+
+  onMounted(async () => {
+    const providersResponse = await fetch("https://esa-eodashboards.github.io/RACE-catalog/providers.json");
+    const providersJson = await providersResponse.json();
+
+    const indicatorsResponse = await fetch("https://esa-eodashboards.github.io/RACE-catalog/RACE/catalog.json");
+    const indicatorsJson = await indicatorsResponse.json();
+    indicators.value = indicatorsJson.links.filter(c => c.rel === "child");
+
+    const narrativesResponse = await fetch("https://esa-eodashboards.github.io/RACE-narratives/narratives.json");
+    narratives.value = await narrativesResponse.json();
+
+    const enhancedProviders = Object.entries(providersJson).map(([key, provider]) => ({
+      ...provider,
+      id: key,
+      indicators: getIndicatorsForProvider(key),
+      narratives: getNarrativesForProvider(key),
+    }));
+    providers.value = enhancedProviders;
+  })
+</script>
+
+


### PR DESCRIPTION
This PR implements rendering of providers as `esa-cards`.

<img width="1407" height="681" alt="image" src="https://github.com/user-attachments/assets/62dfaed8-bed9-4809-b06d-3cbbccb06d51" />
<img width="375" height="774" alt="image" src="https://github.com/user-attachments/assets/d0d7a6ac-ba89-4610-bb97-a6ec00170ee6" />

### Data integration and fetching

* Added logic to fetch provider, indicator, and narrative data from external JSON endpoints, and enhanced provider objects with their associated indicators and narratives.
* Utilized helper functions to associate indicators and narratives with each provider based on their relationships.

### UI and interactivity

* Implemented conditional rendering to show provider cards only when data is loaded, ensuring a responsive and interactive user experience.
* Improved card descriptions with links to provider NoR Offerings, stories, and indicators for easier navigation.

Implements #26.